### PR TITLE
fix js build error

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - type: bind
         source: ./
-        target: /go/app
+        target: /app
       - type: bind
         source: ./.go
         target: /go

--- a/webui/src/api/hooks/useMailsQuery.ts
+++ b/webui/src/api/hooks/useMailsQuery.ts
@@ -57,5 +57,5 @@ export const useMailsQuery = ({ word, date, page }: QueryOptions) =>
   useQuery({
     queryKey: [mailsKeys.index(word, date, page)],
     queryFn: async () => fetchData(word, date, page),
-    keepPreviousData: true,
+    placeholderData: (previousData, _previousQuery) => previousData,
   });


### PR DESCRIPTION
```sh
$ npm run build

> mmbox@0.0.0 build
> tsc && vite build

webui/src/api/hooks/useMailsQuery.ts:60:5 - error TS2769: No overload matches this call.
  Overload 1 of 3, '(options: UndefinedInitialDataOptions<MailsGetResponse, Error, MailsGetResponse, (readonly ["mails", string | undefined, string | undefined, number | undefined])[]>, queryClient?: QueryClient | undefined): UseQueryResult<...>', gave the following error.
    Object literal may only specify known properties, and 'keepPreviousData' does not exist in type 'UndefinedInitialDataOptions<MailsGetResponse, Error, MailsGetResponse, (readonly ["mails", string | undefined, string | undefined, number | undefined])[]>'.
  Overload 2 of 3, '(options: DefinedInitialDataOptions<MailsGetResponse, Error, MailsGetResponse, (readonly ["mails", string | undefined, string | undefined, number | undefined])[]>, queryClient?: QueryClient | undefined): DefinedUseQueryResult<...>', gave the following error.
    Object literal may only specify known properties, and 'keepPreviousData' does not exist in type 'DefinedInitialDataOptions<MailsGetResponse, Error, MailsGetResponse, (readonly ["mails", string | undefined, string | undefined, number | undefined])[]>'.
  Overload 3 of 3, '(options: UseQueryOptions<MailsGetResponse, Error, MailsGetResponse, (readonly ["mails", string | undefined, string | undefined, number | undefined])[]>, queryClient?: QueryClient | undefined): UseQueryResult<...>', gave the following error.
    Object literal may only specify known properties, and 'keepPreviousData' does not exist in type 'UseQueryOptions<MailsGetResponse, Error, MailsGetResponse, (readonly ["mails", string | undefined, string | undefined, number | undefined])[]>'.

60     keepPreviousData: true,
       ~~~~~~~~~~~~~~~~



Found 1 error in webui/src/api/hooks/useMailsQuery.ts:60
```